### PR TITLE
Use sta.js helper instead of defining custom $ERROR and Test262Error

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -31,6 +31,7 @@ module.exports = function compile(test, options) {
 
   let helpers = test.attrs.includes;
   helpers.push('assert.js');
+  helpers.push('sta.js');
   for (var i = 0; i < helpers.length; i++) {
     preludeContents += '\n';
     preludeContents += fs.readFileSync(Path.join(options.includesDir, helpers[i]));

--- a/lib/compilerdeps.js
+++ b/lib/compilerdeps.js
@@ -1,21 +1,3 @@
-function Test262Error(message) {
-    if (message) this.message = message;
-}
-
-Test262Error.prototype.name = "Test262Error";
-
-Test262Error.prototype.toString = function () {
-    return "Test262Error: " + this.message;
-};
-
-function $ERROR(err) {
-  if(typeof err === "object" && err !== null && "name" in err) {
-    print('test262/error ' + err.name + ': ' + err.message);
-  } else {
-    print('test262/error Test262Error: ' + err);
-  }
-}
-
 function $DONE(err) {
   if (err) {
     $ERROR(err);
@@ -27,4 +9,3 @@ function $DONE(err) {
 function $LOG(str) {
   print(str);
 }
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test262-compiler",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Compiles test262 collateral into eshost-executable javascript",
   "main": "lib/compiler.js",
   "bin": {


### PR DESCRIPTION
As per [test262 interpreting docs](https://github.com/tc39/test262/blob/master/INTERPRETING.md#test262-defined-bindings), the `sta.js` file must be included along with `assert.js`. This file defines the `Test262Error` class and the `$ERROR` function.

To test this, I ran

```
test262-harness 'test262/test/harness/*.js'
```

Before this change, only 53/120 tests passed.
After this change, 120/120 tests passed.